### PR TITLE
Fix author typo in main script header

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 # bin/Python3.9
-# Authour : Muhammet Burak GOLEC
+# Author : Muhammet Burak GOLEC
 
 try:    
     import get


### PR DESCRIPTION
## Summary
- fix misspelling in `main.py` author comment

## Testing
- `python -m pytest`
- `python main.py` (fails: IndexError: list assignment index out of range)


------
https://chatgpt.com/codex/tasks/task_e_6893d6d2ad988329862cbc2b33edbb97